### PR TITLE
Update Blueprint.json

### DIFF
--- a/Blueprint/Blueprint.json
+++ b/Blueprint/Blueprint.json
@@ -71,12 +71,6 @@
         "defaultValue": "[concat(parameters('resourcePrefix'), '-sharedsvcs-vnet')]",
         "allowedValues": []
       },
-      "adds_emailNotifications": {
-        "type": "string",
-        "metadata": {
-          "displayName": "Notification email addresses"
-        }
-      },
       "script_executionUserResourceID": {
         "type": "string",
         "metadata": {


### PR DESCRIPTION
Remove the 'aaddsEmailNotifications' parameter.  The AD admins are already on the list, and we don't need to add more explicitly, though it can be done.