### PR TITLE
Added "windows-11" to vmGalleryImageOffer values

### DIFF
--- a/Blueprint/Blueprint.json
+++ b/Blueprint/Blueprint.json
@@ -321,7 +321,8 @@
         "type": "string",
         "allowedValues": [
            "windows-10",
-           "office-365"
+           "office-365",
+           "windows-11"
           ],
         "metadata": {
           "displayName": "Gallery Image Offer"


### PR DESCRIPTION
The value "windows-11" seems to have been added recently, and it needs to be an "AllowedValue" for parameter "avdHostPool_vmGalleryImageOffer".  That is what this change is.